### PR TITLE
fix: use preview-cli directly until symlink issue is resolved

### DIFF
--- a/apps/nativescript-starter-angular/.stackblitzrc
+++ b/apps/nativescript-starter-angular/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/nativescript-starter-javascript/.stackblitzrc
+++ b/apps/nativescript-starter-javascript/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/nativescript-starter-react/.stackblitzrc
+++ b/apps/nativescript-starter-react/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/nativescript-starter-svelte/.stackblitzrc
+++ b/apps/nativescript-starter-svelte/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/nativescript-starter-typescript/.stackblitzrc
+++ b/apps/nativescript-starter-typescript/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview"
+  "startCommand": "./node_modules/.bin/preview-cli"
 }

--- a/apps/nativescript-starter-vue/.stackblitzrc
+++ b/apps/nativescript-starter-vue/.stackblitzrc
@@ -1,5 +1,5 @@
 {
   "installDependencies": true,
   "compileTrigger": "save",
-  "startCommand": "./node_modules/.bin/setup-nativescript-stackblitz && ns preview --no-hmr"
+  "startCommand": "./node_modules/.bin/preview-cli --no-hmr"
 }


### PR DESCRIPTION
Use the `preview-cli` directly rather than our shim CLI.

Reported issue here: https://github.com/stackblitz/webcontainer-core/issues/907
